### PR TITLE
Add PICOT refinement with Gemini

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Stat-Assist is designed to make clinical research design, analysis, and reportin
 - **Statistical Test Recommender**: Automated recommendations for appropriate statistical tests based on study design and variables
 - **Power Calculator**: Interactive sample size and power calculations with visualizations
 - **Protocol Generator**: Automated generation of study protocols based on design inputs
+- **PICOT Refiner**: Converts free-form questions into structured PICOT format using Gemini Flash
 
 ## Technology Stack
 
@@ -73,6 +74,9 @@ stat-assist/
    - Python dependencies for the API service
    - Python dependencies for the PowerSim service
    - Node.js dependencies for the UI service
+
+3. Set the `GEMINI_API_KEY` environment variable with your Gemini Flash API key.
+   This is required for the research question refinement features.
 
 ### Running the Application
 

--- a/statassist-api/app/main.py
+++ b/statassist-api/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI, Depends
 from fastapi.middleware.cors import CORSMiddleware
-from app.routers import auth, studies, variables, statistical
+from app.routers import auth, studies, variables, statistical, research
 from app.db.database import create_tables
 import logging
 
@@ -32,6 +32,7 @@ app.include_router(auth.router, tags=["Authentication"])
 app.include_router(studies.router, tags=["Studies"])
 app.include_router(variables.router, tags=["Variables"])
 app.include_router(statistical.router, tags=["Statistical"])
+app.include_router(research.router, tags=["Research"])
 
 @app.on_event("startup")
 async def startup_event():

--- a/statassist-api/app/routers/research.py
+++ b/statassist-api/app/routers/research.py
@@ -1,0 +1,64 @@
+from fastapi import APIRouter, HTTPException, Depends
+from sqlalchemy.orm import Session
+import logging
+
+from app.db.database import get_db
+from app.routers.auth import get_current_user
+from app.models.user import User
+from app.schemas.research import (
+    PICOTRequest,
+    PICOTResponse,
+    TIRRequest,
+    TIRResponse,
+)
+from app.utils.gemini import call_gemini
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/research")
+
+
+@router.post("/picot", response_model=PICOTResponse)
+async def refine_to_picot(
+    request: PICOTRequest,
+    db: Session = Depends(get_db),  # noqa: F401 - future use
+    current_user: User = Depends(get_current_user),
+):
+    """Refine an arbitrary research question into PICOT components using Gemini."""
+    prompt = (
+        "Convert the following clinical research question into PICOT format. "
+        "Respond in JSON with keys population, intervention, comparator, outcome, "
+        "and timeframe if available. If any component is missing, set clarification_needed to true "
+        "and provide best guess values. Question: "
+        f"{request.question}\nAdditional context: {request.additional_details}"
+    )
+    try:
+        response = call_gemini(prompt)
+        # The service is expected to return JSON in the text field
+        data = response.get("text", "{}")
+        picot_data = PICOTResponse.model_validate_json(data)
+    except Exception as exc:  # pragma: no cover - external call
+        logger.error("Gemini API error: %s", exc)
+        raise HTTPException(status_code=500, detail="LLM processing failed")
+    return picot_data
+
+
+@router.post("/tir", response_model=TIRResponse)
+async def generate_tir(
+    request: TIRRequest,
+    db: Session = Depends(get_db),  # noqa: F401 - future use
+    current_user: User = Depends(get_current_user),
+):
+    """Generate a text-based statistical plan using the refined PICOT question."""
+    prompt = (
+        "Using the following PICOT formatted question, outline the recommended "
+        "statistical tests, sample size considerations and interpretation steps.\n"
+        f"PICOT: {request.picot}"
+    )
+    try:
+        response = call_gemini(prompt)
+        text = response.get("text", "")
+    except Exception as exc:  # pragma: no cover - external call
+        logger.error("Gemini API error: %s", exc)
+        raise HTTPException(status_code=500, detail="LLM processing failed")
+    return TIRResponse(analysis_plan=text)

--- a/statassist-api/app/schemas/research.py
+++ b/statassist-api/app/schemas/research.py
@@ -1,0 +1,34 @@
+from pydantic import BaseModel, Field
+from typing import Optional, Dict, Any
+
+
+class PICOTRequest(BaseModel):
+    """Request schema for refining a research question into PICOT."""
+
+    question: str = Field(..., description="Initial research question")
+    additional_details: Optional[str] = Field(
+        None, description="Any extra context or notes from the user"
+    )
+
+
+class PICOTResponse(BaseModel):
+    """Response schema containing PICOT components."""
+
+    population: str
+    intervention: str
+    comparator: str
+    outcome: str
+    timeframe: Optional[str] = None
+    clarification_needed: bool = False
+
+
+class TIRRequest(BaseModel):
+    """Request schema for generating a statistical plan from a PICOT question."""
+
+    picot: Dict[str, Any]
+
+
+class TIRResponse(BaseModel):
+    """Response containing the text-based plan from the language model."""
+
+    analysis_plan: str

--- a/statassist-api/app/utils/gemini.py
+++ b/statassist-api/app/utils/gemini.py
@@ -1,0 +1,32 @@
+import os
+import logging
+from typing import Any, Dict
+
+try:
+    import google.generativeai as genai
+except ImportError:  # pragma: no cover - optional dependency
+    genai = None
+
+logger = logging.getLogger(__name__)
+
+GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
+GEMINI_MODEL = os.getenv("GEMINI_MODEL", "gemini-1.5-flash-latest")
+
+
+def call_gemini(prompt: str, **kwargs: Any) -> Dict[str, Any]:
+    """Call the Gemini Flash API and return the response.
+
+    This is a thin wrapper so that the rest of the code can rely on a single
+    function. If the ``google-generativeai`` package is not installed or the
+    API key is missing, a ``RuntimeError`` is raised.
+    """
+    if genai is None:
+        raise RuntimeError("google-generativeai package is not installed")
+    if not GEMINI_API_KEY:
+        raise RuntimeError("GEMINI_API_KEY environment variable not set")
+
+    genai.configure(api_key=GEMINI_API_KEY)
+    model = genai.GenerativeModel(GEMINI_MODEL)
+    logger.info("Calling Gemini model %s", GEMINI_MODEL)
+    response = model.generate_content(prompt, **kwargs)
+    return {"text": response.text}

--- a/statassist-api/requirements.txt
+++ b/statassist-api/requirements.txt
@@ -8,3 +8,4 @@ python-dotenv==1.0.0
 httpx==0.25.1
 python-multipart==0.0.6
 email-validator==2.1.0
+google-generativeai==0.5.0

--- a/statassist-ui/src/app/picot/page.tsx
+++ b/statassist-ui/src/app/picot/page.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+
+interface PICOT {
+  population: string;
+  intervention: string;
+  comparator: string;
+  outcome: string;
+  timeframe?: string;
+  clarification_needed?: boolean;
+}
+
+export default function PicotPage() {
+  const [question, setQuestion] = useState('');
+  const [details, setDetails] = useState('');
+  const [picot, setPicot] = useState<PICOT | null>(null);
+  const [analysis, setAnalysis] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const submitQuestion = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/v1/research/picot', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ question, additional_details: details }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setPicot(data);
+      } else {
+        throw new Error('Failed to refine question');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const finalize = async () => {
+    if (!picot) return;
+    setLoading(true);
+    try {
+      const res = await fetch('/api/v1/research/tir', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ picot }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setAnalysis(data.analysis_plan);
+      } else {
+        throw new Error('Failed to generate plan');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="container py-8 space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Refine Research Question</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Textarea
+            placeholder="Enter your research question"
+            value={question}
+            onChange={(e) => setQuestion(e.target.value)}
+          />
+          <Input
+            placeholder="Additional details (optional)"
+            value={details}
+            onChange={(e) => setDetails(e.target.value)}
+          />
+          <Button onClick={submitQuestion} disabled={loading || !question}>
+            Refine to PICOT
+          </Button>
+        </CardContent>
+      </Card>
+
+      {picot && (
+        <Card>
+          <CardHeader>
+            <CardTitle>PICOT</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <Input
+              value={picot.population}
+              onChange={(e) =>
+                setPicot({ ...picot, population: e.target.value })
+              }
+              placeholder="Population"
+            />
+            <Input
+              value={picot.intervention}
+              onChange={(e) =>
+                setPicot({ ...picot, intervention: e.target.value })
+              }
+              placeholder="Intervention"
+            />
+            <Input
+              value={picot.comparator}
+              onChange={(e) =>
+                setPicot({ ...picot, comparator: e.target.value })
+              }
+              placeholder="Comparator"
+            />
+            <Input
+              value={picot.outcome}
+              onChange={(e) => setPicot({ ...picot, outcome: e.target.value })}
+              placeholder="Outcome"
+            />
+            <Input
+              value={picot.timeframe || ''}
+              onChange={(e) =>
+                setPicot({ ...picot, timeframe: e.target.value })
+              }
+              placeholder="Timeframe"
+            />
+            <Button onClick={finalize} disabled={loading}>
+              Generate Analysis Plan
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {analysis && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Analysis Plan</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <pre className="whitespace-pre-wrap">{analysis}</pre>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}
+

--- a/statassist-ui/src/components/ui/textarea.tsx
+++ b/statassist-ui/src/components/ui/textarea.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => (
+    <textarea
+      className={cn(
+        'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  )
+);
+Textarea.displayName = 'Textarea';
+
+export { Textarea };
+


### PR DESCRIPTION
## Summary
- integrate Gemini Flash via new gemini util
- add research router with endpoints to refine questions and generate plans
- expose new router in FastAPI app
- document new PICOT feature and setup for GEMINI_API_KEY
- add PICOT refinement page in Next.js UI with textarea component

## Testing
- `git status --short`
- `git commit -m "Add PICOT refinement and Gemini integration"`


------
https://chatgpt.com/codex/tasks/task_e_684bf84eaf208330b9bc0fd60ae754a9